### PR TITLE
Standardize navbar rendering and behavior across pages

### DIFF
--- a/ProjectSourceCode/index.html
+++ b/ProjectSourceCode/index.html
@@ -16,41 +16,7 @@
     />
   </head>
   <body class="bg-light text-dark">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
-      <div class="container">
-        <a class="navbar-brand fw-bold" href="#">Task Tracker 0.0.2</a>
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#mainNavbar"
-          aria-controls="mainNavbar"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse justify-content-end" id="mainNavbar">
-          <ul class="navbar-nav align-items-lg-center gap-2">
-            <li class="nav-item">
-              <a class="btn btn-light btn-sm fw-semibold" href="pages/login.html">Login</a>
-            </li>
-            <li class="nav-item">
-              <a class="btn btn-outline-light btn-sm fw-semibold" href="pages/register.html">Register</a>
-            </li>
-            <li class="nav-item">
-              <a class="btn btn-outline-light btn-sm fw-semibold" href="pages/kanban.html">Tasks</a>
-            </li>
-            <li class="nav-item">
-              <button class="btn btn-outline-light btn-sm fw-semibold" type="button">Service Status</button>
-            </li>
-            <li class="nav-item ms-lg-2">
-              <span class="navbar-text text-white-50">Team Choo Choo Trains</span>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+    <div id="siteNavbar"></div>
 
     <header class="py-5 bg-white border-bottom">
       <div class="container">
@@ -158,46 +124,10 @@
       crossorigin="anonymous"
     ></script>
     <script src="scripts/notifications.js"></script>
+    <script src="scripts/navbar.js"></script>
     <script>
-      document.addEventListener('DOMContentLoaded', async () => {
-        const token = localStorage.getItem('token');
-        if (token) {
-          try {
-            const res = await fetch('/api/auth/get-user', {
-              headers: { 'Authorization': `Bearer ${token}` }
-            });
-            if (res.ok) {
-              const data = await res.json();
-              const username = data.user.username;
-              
-              // Hide login/register
-              const loginBtn = document.querySelector('a[href="pages/login.html"]')?.parentElement;
-              const registerBtn = document.querySelector('a[href="pages/register.html"]')?.parentElement;
-              if (loginBtn) loginBtn.style.display = 'none';
-              if (registerBtn) registerBtn.style.display = 'none';
-
-              // Show User
-              const navBar = document.querySelector('.navbar-nav');
-              
-              const userLi = document.createElement('li');
-              userLi.className = 'nav-item d-flex align-items-center gap-2 ms-lg-3';
-              userLi.innerHTML = `
-                <span class="text-white fw-semibold">Hello, ${username}</span>
-                <button class="btn btn-sm btn-outline-danger" id="logoutBtn">Logout</button>
-              `;
-              navBar.appendChild(userLi);
-
-              document.getElementById('logoutBtn').addEventListener('click', () => {
-                localStorage.removeItem('token');
-                window.location.reload();
-              });
-            } else {
-              localStorage.removeItem('token');
-            }
-          } catch (e) {
-            console.error('Failed to fetch user', e);
-          }
-        }
+      document.addEventListener('DOMContentLoaded', () => {
+        initNavbar({ basePath: '', currentPage: 'home' });
       });
     </script>
   </body>

--- a/ProjectSourceCode/pages/kanban.html
+++ b/ProjectSourceCode/pages/kanban.html
@@ -35,21 +35,7 @@
     </style>
   </head>
   <body class="bg-light text-dark">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
-      <div class="container">
-        <a class="navbar-brand fw-bold" href="/">Task Tracker 0.0.2</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse justify-content-end" id="mainNavbar">
-          <ul class="navbar-nav align-items-lg-center gap-2">
-            <li class="nav-item"><a class="btn btn-outline-light btn-sm fw-semibold" href="/">Home</a></li>
-            <li class="nav-item"><a class="btn btn-light btn-sm fw-semibold" href="./kanban.html">Tasks</a></li>
-            <li class="nav-item ms-lg-2"><span class="navbar-text text-white-50">Team Choo Choo Trains</span></li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+    <div id="siteNavbar"></div>
 
     <main class="py-4 py-lg-5">
       <div class="container">
@@ -331,6 +317,12 @@
       crossorigin="anonymous"
     ></script>
     <style>.pac-container { z-index: 9999 !important; }</style>
+    <script src="../scripts/navbar.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        initNavbar({ basePath: '..', currentPage: 'tasks' });
+      });
+    </script>
     <script src="../scripts/map.js"></script>
     <script src="../scripts/kanban.js"></script>
     <script src="../scripts/notifications.js"></script>

--- a/ProjectSourceCode/pages/login.html
+++ b/ProjectSourceCode/pages/login.html
@@ -80,41 +80,7 @@
 </head>
 <body>
 
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
-    <div class="container">
-      <a class="navbar-brand fw-bold" href="/">Task Tracker 0.0.2</a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#mainNavbar"
-        aria-controls="mainNavbar"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse justify-content-end" id="mainNavbar">
-        <ul class="navbar-nav align-items-lg-center gap-2">
-          <li class="nav-item">
-            <a class="btn btn-light btn-sm fw-semibold" href="login.html">Login</a>
-          </li>
-          <li class="nav-item">
-            <a class="btn btn-outline-light btn-sm fw-semibold" href="register.html">Register</a>
-          </li>
-          <li class="nav-item">
-            <a class="btn btn-outline-light btn-sm fw-semibold" href="kanban.html">Tasks</a>
-          </li>
-          <li class="nav-item">
-            <button class="btn btn-outline-light btn-sm fw-semibold" type="button">Service Status</button>
-          </li>
-          <li class="nav-item ms-lg-2">
-            <span class="navbar-text text-white-50">Team Choo Choo Trains</span>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </nav>
+  <div id="siteNavbar"></div>
 
   <div class="form-wrapper">
     <form id="loginForm">
@@ -143,6 +109,12 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
     crossorigin="anonymous"></script>
+  <script src="../scripts/navbar.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initNavbar({ basePath: '..', currentPage: 'login' });
+    });
+  </script>
   <script src="../scripts/login.js"></script>
 </body>
 </html>

--- a/ProjectSourceCode/pages/register.html
+++ b/ProjectSourceCode/pages/register.html
@@ -95,41 +95,7 @@
 </head>
 <body>
 
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
-    <div class="container">
-      <a class="navbar-brand fw-bold" href="../index.html">Task Tracker 0.0.1</a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#mainNavbar"
-        aria-controls="mainNavbar"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse justify-content-end" id="mainNavbar">
-        <ul class="navbar-nav align-items-lg-center gap-2">
-          <li class="nav-item">
-            <a class="btn btn-light btn-sm fw-semibold" href="login.html">Login</a>
-          </li>
-          <li class="nav-item">
-            <a class="btn btn-outline-light btn-sm fw-semibold" href="register.html">Register</a>
-          </li>
-          <li class="nav-item">
-            <button class="btn btn-outline-light btn-sm fw-semibold" type="button">Tasks</button>
-          </li>
-          <li class="nav-item">
-            <button class="btn btn-outline-light btn-sm fw-semibold" type="button">Service Status</button>
-          </li>
-          <li class="nav-item ms-lg-2">
-            <span class="navbar-text text-white-50">Team Choo Choo Trains</span>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </nav>
+  <div id="siteNavbar"></div>
 
   <div class="form-wrapper">
     <form id="registerForm">
@@ -164,6 +130,12 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
     crossorigin="anonymous"></script>
+  <script src="../scripts/navbar.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initNavbar({ basePath: '..', currentPage: 'register' });
+    });
+  </script>
   <script src="../scripts/register.js"></script>
 </body>
 </html>

--- a/ProjectSourceCode/scripts/navbar.js
+++ b/ProjectSourceCode/scripts/navbar.js
@@ -1,0 +1,88 @@
+function initNavbar({ mountId = 'siteNavbar', basePath = '', currentPage = '' } = {}) {
+  const mount = document.getElementById(mountId);
+  if (!mount) return;
+
+  const normalizedBasePath = basePath && !basePath.endsWith('/') ? `${basePath}/` : basePath;
+  const links = {
+    home: `${normalizedBasePath}index.html`,
+    login: `${normalizedBasePath}pages/login.html`,
+    register: `${normalizedBasePath}pages/register.html`,
+    tasks: `${normalizedBasePath}pages/kanban.html`,
+  };
+
+  const activeClass = (page) =>
+    currentPage === page ? 'btn btn-light btn-sm fw-semibold' : 'btn btn-outline-light btn-sm fw-semibold';
+
+  mount.innerHTML = `
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
+      <div class="container">
+        <a class="navbar-brand fw-bold" href="${links.home}">Task Tracker 0.0.2</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNavbar"
+          aria-controls="mainNavbar"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="mainNavbar">
+          <ul class="navbar-nav align-items-lg-center gap-2">
+            <li class="nav-item"><a class="${activeClass('home')}" href="${links.home}">Home</a></li>
+            <li class="nav-item" data-auth="login"><a class="${activeClass('login')}" href="${links.login}">Login</a></li>
+            <li class="nav-item" data-auth="register"><a class="${activeClass('register')}" href="${links.register}">Register</a></li>
+            <li class="nav-item"><a class="${activeClass('tasks')}" href="${links.tasks}">Tasks</a></li>
+            <li class="nav-item">
+              <button class="btn btn-outline-light btn-sm fw-semibold" type="button">Service Status</button>
+            </li>
+            <li class="nav-item ms-lg-2">
+              <span class="navbar-text text-white-50">Team Choo Choo Trains</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  `;
+
+  hydrateAuthState(mount);
+}
+
+async function hydrateAuthState(navRoot) {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+
+  try {
+    const res = await fetch('/api/auth/get-user', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!res.ok) {
+      localStorage.removeItem('token');
+      return;
+    }
+
+    const data = await res.json();
+    const username = data.user?.username || 'User';
+
+    navRoot.querySelector('[data-auth="login"]')?.remove();
+    navRoot.querySelector('[data-auth="register"]')?.remove();
+
+    const navBar = navRoot.querySelector('.navbar-nav');
+    const userLi = document.createElement('li');
+    userLi.className = 'nav-item d-flex align-items-center gap-2 ms-lg-3';
+    userLi.innerHTML = `
+      <span class="text-white fw-semibold">Hello, ${username}</span>
+      <button class="btn btn-sm btn-outline-danger" id="logoutBtn" type="button">Logout</button>
+    `;
+    navBar?.appendChild(userLi);
+
+    navRoot.querySelector('#logoutBtn')?.addEventListener('click', () => {
+      localStorage.removeItem('token');
+      window.location.reload();
+    });
+  } catch (error) {
+    console.error('Failed to fetch user', error);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for the site navigation so every page shows the same navbar and active-state styling.
- Centralize auth-aware UI behavior (hide `Login`/`Register` and show greeting + `Logout`) to avoid duplicating logic across pages.

### Description
- Add a shared script `ProjectSourceCode/scripts/navbar.js` which exposes `initNavbar()` and `hydrateAuthState()` to render the navbar and apply auth state.
- Replace inline navbar markup with a mount point `<div id="siteNavbar"></div>` in `ProjectSourceCode/index.html`, `ProjectSourceCode/pages/login.html`, `ProjectSourceCode/pages/register.html`, and `ProjectSourceCode/pages/kanban.html`.
- Load `scripts/navbar.js` on each modified page and call `initNavbar({ basePath: ..., currentPage: '...' })` to set correct link paths and the active button.
- Preserve existing links and styling (Home/Login/Register/Tasks/Service Status/branding) and wire up logout to clear `localStorage` and reload the page.

### Testing
- Ran a file-read sanity check via `node -e "..."` to confirm the updated files are readable and the new script exists, which passed.
- Ran `npm test -- --runInBand` which failed to start due to missing environment configuration (`SESSION_SECRET` is not set) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f1565e08325847818e7845794df)